### PR TITLE
空文字の場合は重複チェック除外

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -193,7 +193,11 @@ export default {
       this.doubleName = false; 
       for (let i = 0;  i < this.todayReviewers.length; i++) {
         let countName = 0;
+        if(this.todayReviewers[i] ==''){
+          continue;
+        }
         for(let s = 0; s < this.todayReviewers.length; s++){
+
           if(this.todayReviewers[i] == this.todayReviewers[s]){
             countName++;
             if(countName == 2){

--- a/src/App.vue
+++ b/src/App.vue
@@ -193,11 +193,10 @@ export default {
       this.doubleName = false; 
       for (let i = 0;  i < this.todayReviewers.length; i++) {
         let countName = 0;
-        if(this.todayReviewers[i] ==''){
+        if(this.todayReviewers[i] == ''){
           continue;
         }
         for(let s = 0; s < this.todayReviewers.length; s++){
-
           if(this.todayReviewers[i] == this.todayReviewers[s]){
             countName++;
             if(countName == 2){


### PR DESCRIPTION
■概要
レビュアー重複チェックの際、初期値の空文字も判定してしまっていたので、空文字の場合はチェック対象外とした。